### PR TITLE
Simplify grocery list by removing measurement unit field

### DIFF
--- a/backend/WhatIsInMyFridge.Api/Dtos/CreateGroceryItemRequest.cs
+++ b/backend/WhatIsInMyFridge.Api/Dtos/CreateGroceryItemRequest.cs
@@ -12,8 +12,6 @@ public sealed class CreateGroceryItemRequest
     [Range(0, double.MaxValue)]
     public decimal? Quantity { get; set; }
 
-    public MeasurementUnit? Unit { get; set; }
-
     public FoodCategory Category { get; set; } = FoodCategory.Undefined;
 
     [StringLength(500)]

--- a/backend/WhatIsInMyFridge.Api/Dtos/UpdateGroceryItemRequest.cs
+++ b/backend/WhatIsInMyFridge.Api/Dtos/UpdateGroceryItemRequest.cs
@@ -11,8 +11,6 @@ public sealed class UpdateGroceryItemRequest
     [Range(0, double.MaxValue)]
     public decimal? Quantity { get; set; }
 
-    public MeasurementUnit? Unit { get; set; }
-
     public FoodCategory? Category { get; set; }
 
     [StringLength(500)]

--- a/backend/WhatIsInMyFridge.Api/Migrations/20251030212131_RemoveUnitFromGroceryItem.Designer.cs
+++ b/backend/WhatIsInMyFridge.Api/Migrations/20251030212131_RemoveUnitFromGroceryItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WhatIsInMyFridge.Api.Services;
 
@@ -10,9 +11,11 @@ using WhatIsInMyFridge.Api.Services;
 namespace WhatIsInMyFridge.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251030212131_RemoveUnitFromGroceryItem")]
+    partial class RemoveUnitFromGroceryItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");
@@ -99,6 +102,9 @@ namespace WhatIsInMyFridge.Api.Migrations
                         .HasColumnType("TEXT");
 
                     b.Property<decimal?>("Quantity")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Unit")
                         .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset>("UpdatedAt")

--- a/backend/WhatIsInMyFridge.Api/Migrations/20251030212131_RemoveUnitFromGroceryItem.cs
+++ b/backend/WhatIsInMyFridge.Api/Migrations/20251030212131_RemoveUnitFromGroceryItem.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WhatIsInMyFridge.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUnitFromGroceryItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/backend/WhatIsInMyFridge.Api/Migrations/20251030212238_RemoveUnitColumnFromGroceryItem.Designer.cs
+++ b/backend/WhatIsInMyFridge.Api/Migrations/20251030212238_RemoveUnitColumnFromGroceryItem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WhatIsInMyFridge.Api.Services;
 
@@ -10,9 +11,11 @@ using WhatIsInMyFridge.Api.Services;
 namespace WhatIsInMyFridge.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251030212238_RemoveUnitColumnFromGroceryItem")]
+    partial class RemoveUnitColumnFromGroceryItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/backend/WhatIsInMyFridge.Api/Migrations/20251030212238_RemoveUnitColumnFromGroceryItem.cs
+++ b/backend/WhatIsInMyFridge.Api/Migrations/20251030212238_RemoveUnitColumnFromGroceryItem.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WhatIsInMyFridge.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUnitColumnFromGroceryItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Unit",
+                table: "GroceryItems");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Unit",
+                table: "GroceryItems",
+                type: "TEXT",
+                nullable: true);
+        }
+    }
+}

--- a/backend/WhatIsInMyFridge.Api/Models/GroceryItem.cs
+++ b/backend/WhatIsInMyFridge.Api/Models/GroceryItem.cs
@@ -6,7 +6,6 @@ public sealed class GroceryItem
     public string HouseholdId { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public decimal? Quantity { get; set; }
-    public MeasurementUnit? Unit { get; set; }
     public FoodCategory Category { get; set; } = FoodCategory.Undefined;
     public string? Notes { get; set; }
     public bool IsPurchased { get; set; } = false;

--- a/backend/WhatIsInMyFridge.Api/Services/AppDbContext.cs
+++ b/backend/WhatIsInMyFridge.Api/Services/AppDbContext.cs
@@ -114,8 +114,6 @@ public sealed class AppDbContext : DbContext
             entity.HasKey(e => e.Id);
             entity.Property(e => e.HouseholdId).IsRequired();
             entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Unit)
-                .HasConversion<string>();
             entity.Property(e => e.Category)
                 .HasConversion<string>();
             entity.Property(e => e.Notes).HasMaxLength(500);

--- a/backend/WhatIsInMyFridge.Api/Services/GroceryListStore.cs
+++ b/backend/WhatIsInMyFridge.Api/Services/GroceryListStore.cs
@@ -38,7 +38,6 @@ public sealed class GroceryListStore
             HouseholdId = householdId,
             Name = request.Name.Trim(),
             Quantity = request.Quantity,
-            Unit = request.Unit,
             Category = request.Category,
             Notes = request.Notes?.Trim(),
             IsPurchased = false,
@@ -58,7 +57,6 @@ public sealed class GroceryListStore
 
         existing.Name = request.Name is { Length: > 0 } name ? name.Trim() : existing.Name;
         existing.Quantity = request.Quantity ?? existing.Quantity;
-        existing.Unit = request.Unit ?? existing.Unit;
         existing.Category = request.Category ?? existing.Category;
         existing.Notes = request.Notes is { Length: > 0 } notes ? notes.Trim() : request.Notes == string.Empty ? null : existing.Notes;
         existing.IsPurchased = request.IsPurchased ?? existing.IsPurchased;

--- a/frontend/src/lib/GroceryList.svelte
+++ b/frontend/src/lib/GroceryList.svelte
@@ -3,67 +3,40 @@
   import { apiClient } from './api';
   import type { components } from './api-types';
 
-  type GroceryItem = components['schemas']['GroceryItem'];
   type FoodCategory = components['schemas']['FoodCategory'];
-  type MeasurementUnit = components['schemas']['MeasurementUnit'];
+
+  interface GroceryItem {
+    id: string;
+    householdId: string;
+    name: string;
+    quantity?: number | null;
+    category: FoodCategory;
+    notes?: string | null;
+    isPurchased: boolean;
+    createdAt: string;
+    updatedAt: string;
+  }
 
   let groceryItems: GroceryItem[] = [];
   let newItemName = '';
   let newItemQuantity = '';
-  let newItemUnit: MeasurementUnit | '' = '';
-  let newItemCategory: FoodCategory = 'other';
+  let newItemCategory: FoodCategory = 'Other';
   let newItemNotes = '';
   let loading = false;
   let error = '';
 
   const categories: FoodCategory[] = [
-    'fruit',
-    'vegetable',
-    'meat',
-    'dairy',
-    'grain',
-    'condiment',
-    'beverage',
-    'snack',
-    'frozen',
-    'other'
+    'Fruits',
+    'Vegetables',
+    'Meat',
+    'Dairy',
+    'Bread',
+    'Condiments',
+    'Beverages',
+    'Snacks',
+    'FrozenMeals',
+    'Other'
   ];
-
-  const units: (MeasurementUnit | '')[] = [
-    '',
-    'piece',
-    'lb',
-    'oz',
-    'kg',
-    'g',
-    'cup',
-    'tbsp',
-    'tsp',
-    'ml',
-    'l',
-    'gallon',
-    'quart',
-    'pint',
-    'fl_oz'
-  ];
-
-  const unitLabels: Record<string, string> = {
-    '': '(none)',
-    piece: 'piece(s)',
-    lb: 'lb',
-    oz: 'oz',
-    kg: 'kg',
-    g: 'g',
-    cup: 'cup(s)',
-    tbsp: 'tbsp',
-    tsp: 'tsp',
-    ml: 'ml',
-    l: 'L',
-    gallon: 'gallon(s)',
-    quart: 'quart(s)',
-    pint: 'pint(s)',
-    fl_oz: 'fl oz'
-  };
 
   onMount(() => {
     loadGroceryItems();
@@ -78,7 +51,7 @@
         error = 'Failed to load grocery list';
         console.error(apiError);
       } else {
-        groceryItems = data || [];
+        groceryItems = (data as any) || [];
       }
     } catch (err) {
       error = 'Failed to load grocery list';
@@ -94,11 +67,11 @@
     loading = true;
     error = '';
     try {
+      const quantityValue = newItemQuantity.trim() ? parseFloat(newItemQuantity.trim()) : null;
       const { data, error: apiError } = await apiClient.POST('/api/grocery', {
         body: {
           name: newItemName.trim(),
-          quantity: newItemQuantity.trim() || null,
-          unit: newItemUnit || null,
+          quantity: quantityValue,
           category: newItemCategory,
           notes: newItemNotes.trim() || null
         }
@@ -108,12 +81,11 @@
         error = 'Failed to add item';
         console.error(apiError);
       } else if (data) {
-        groceryItems = [...groceryItems, data];
+        groceryItems = [...groceryItems, data as any];
         // Reset form
         newItemName = '';
         newItemQuantity = '';
-        newItemUnit = '';
-        newItemCategory = 'other';
+        newItemCategory = 'Other';
         newItemNotes = '';
       }
     } catch (err) {
@@ -137,7 +109,7 @@
         error = 'Failed to update item';
         console.error(apiError);
       } else if (data) {
-        groceryItems = groceryItems.map(i => i.id === item.id ? data : i);
+        groceryItems = groceryItems.map(i => i.id === item.id ? (data as any) : i);
       }
     } catch (err) {
       error = 'Failed to update item';
@@ -192,13 +164,7 @@
   }
 
   function formatQuantity(item: GroceryItem): string {
-    if (!item.quantity && !item.unit) return '';
-    if (item.quantity && item.unit) {
-      return `${item.quantity} ${unitLabels[item.unit] || item.unit}`;
-    }
-    if (item.quantity) return item.quantity;
-    if (item.unit) return unitLabels[item.unit] || item.unit;
-    return '';
+    return item.quantity ? String(item.quantity) : '';
   }
 
   $: unpurchasedCount = groceryItems.filter(i => !i.isPurchased).length;
@@ -224,17 +190,13 @@
           required
         />
         <input
-          type="text"
+          type="number"
+          step="any"
           placeholder="Quantity (optional)"
           bind:value={newItemQuantity}
           disabled={loading}
-          style="max-width: 120px;"
+          style="max-width: 200px;"
         />
-        <select bind:value={newItemUnit} disabled={loading} style="max-width: 120px;">
-          {#each units as unit}
-            <option value={unit}>{unitLabels[unit] || unit}</option>
-          {/each}
-        </select>
       </div>
       <div class="form-row">
         <select bind:value={newItemCategory} disabled={loading}>


### PR DESCRIPTION
## Summary
- Streamline grocery list UX by removing measurement unit selection
- Users now enter only a numeric quantity without specifying units (lb, oz, etc.)
- Applied database migration to drop Unit column from GroceryItem table
- Updated DTOs, business logic, and frontend form to reflect simplified model